### PR TITLE
Fixed "Core Miner" technology prerequisites

### DIFF
--- a/DyComPa/data/tech/space-exploration.lua
+++ b/DyComPa/data/tech/space-exploration.lua
@@ -38,7 +38,7 @@ DyW.Tech.Prereq.Override("se-biological-science-pack-1", {"se-processing-vitamel
 DyW.Tech.Prereq.Override("se-biological-science-pack-2", {"se-space-catalogue-biological-2", "se-bioscrubber"})
 DyW.Tech.Prereq.Override("se-biological-science-pack-3", {"se-space-catalogue-biological-3"})
 DyW.Tech.Prereq.Override("se-biological-science-pack-4", {"se-space-catalogue-biological-4"})
-DyW.Tech.Prereq.Override("se-core-miner", {"se-pulveriser", "oil-processing-2", "logistic-science-pack-advanced"})
+DyW.Tech.Prereq.Override("se-core-miner", {"se-pulveriser", "oil-processing-2", "logistic-science-pack"})
 DyW.Tech.Prereq.Override("se-cryogun", {"se-aeroframe-pole", "se-processing-cryonite", "se-space-thermodynamics-laboratory", "warfare-10"})
 DyW.Tech.Prereq.Override("se-meteor-point-defence", {"intermediates-2", "logistic-science-pack"})
 DyW.Tech.Prereq.Override("se-meteor-defence", {"chemical-science-pack", "se-meteor-point-defence", "intermediates-5"})


### PR DESCRIPTION
I'm not 100% sure if this is intended but I found weird that `Core Miner` had `Advanced Logistical Science Pack` as a prerequisite when the technology itself only needs `Logistical Science Pack`. Also `Core Miner` is a prerequisite to vulcanite processing and basically every space technology.