### PR TITLE
Fixed sending player-ambush when on remote view

### DIFF
--- a/DyWorld-Dynamics/script/events/on_tick.lua
+++ b/DyWorld-Dynamics/script/events/on_tick.lua
@@ -240,7 +240,7 @@ function Event_on_tick(event)
 					end
 				elseif Dy_Find_Str(v, "player-ambush") then
 					for _,player in pairs(global.dyworld.players) do
-						if not Dy_Find_Str(player.surface, "starmap") then
+						if not Dy_Find_Str(player.surface, "starmap") and not remote.call("space-exploration", "remote_view_is_active", {player = game.players[player.id]}) then
 							local Location = {player.posx, player.posy, player.surface}
 							local Str = Pick_Random_Attack_Strength(math.ceil(global.dyworld.game_stats.difficulty / 2000))
 							if Dy_Find_Str(v, "101") then


### PR DESCRIPTION
When I was on remote view the "player ambush" attacks were sent to where I was looking at in the remote view, instead of where my "real" character position.
So, for now, I disabled the player ambush when the player is on remote view, ideally it should send the attack to the real player character position.