### PR TITLE
Fixed recipes that produce 'stone' as a by-product

### DIFF
--- a/DyComPa/data/recipes/space-exploration.lua
+++ b/DyComPa/data/recipes/space-exploration.lua
@@ -41,3 +41,48 @@ if data.raw.recipe["se-cargo-rocket-cargo-pod"] then
 		{ "normal-inserter", 2 }
 	}
 end
+if data.raw.recipe["se-core-fragment-omni"] then
+	for recipe_name,_ in pairs(data.raw.recipe) do
+		if (string.find(recipe_name, "se-core-fragment-", 1, true) == 1) then
+			for i,result in pairs(data.raw.recipe[recipe_name].results) do
+				if (result.name == "stone" or
+						recipe_name == "se-core-fragment-omni" and (result.name == "wood" or result.name == "carrot")) then
+					data.raw.recipe[recipe_name].results[i] = nil
+				end
+			end
+		end
+	end
+end
+if data.raw.recipe["scrap-recycling"] then
+	data.raw.recipe["scrap-recycling"].results = {
+		{ name = "tin-ore", amount_min = 1, amount_max = 1, probability = 0.1},
+		{ name = "copper-ore", amount_min = 1, amount_max = 1, probability = 0.1},
+		{ name = "iron-ore", amount_min = 1, amount_max = 1, probability = 0.1},
+		{ type = "fluid", name = "heavy-oil", amount_min = 1, amount_max = 1, probability = 0.1},
+	}
+end
+if data.raw.recipe["se-vulcanite-washed"] then
+	data.raw.recipe["se-vulcanite-washed"].results[2] = {
+		name = "limestone", amount_min = 1, amount_max = 1, probability = 0.25
+	}
+end
+if data.raw.recipe["se-cryonite-washed"] then
+	data.raw.recipe["se-cryonite-washed"].results[2] = {
+		name = "limestone", amount_min = 1, amount_max = 1, probability = 0.25
+	}
+end
+if data.raw.recipe["se-holmium-ore-washed"] then
+	data.raw.recipe["se-holmium-ore-washed"].results[2] = {
+		name = "limestone", amount_min = 1, amount_max = 1, probability = 0.25
+	}
+end
+if data.raw.recipe["se-iridium-ore-washed"] then
+	data.raw.recipe["se-iridium-ore-washed"].results[2] = {
+		name = "limestone", amount_min = 1, amount_max = 1, probability = 0.25
+	}
+end
+if data.raw.recipe["se-naquium-ore-washed"] then
+	data.raw.recipe["se-naquium-ore-washed"].results[2] = {
+		name = "limestone", amount_min = 1, amount_max = 1, probability = 0.25
+	}
+end


### PR DESCRIPTION
Replaced some recipes that were producing `stone` as a by-product with `limestone`.
Also removed `wood` and `carrot` from `se-core-fragment-omni` (the nauvis core fragment), it was creating a massive amount of `wood` and `carrot` which would make other wood-producing methods obsolete.